### PR TITLE
Now allows to fine control the test events order

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,4 +2,4 @@
 
 * Hamidreza Afzali 
 * Jendrik Poloczek 
-
+* Svend Vanderveken

--- a/README.md
+++ b/README.md
@@ -49,6 +49,26 @@ It also allows you to have multiple input and output streams. If your topology u
     mstreams.output("out-a", strings, ints, expA.size) shouldEqual(expectedA)
     mstreams.output("out-b", strings, ints, expB.size) shouldEqual(expectedB)
 
+## Event order and multiple emissions
+
+The events provided to the mock stream will be submitted to the topology during the test in the order in which they appear in the fixture. You can also submit events multiple times to the same topics, at various moments in your scenario. 
+
+This can be handy to validate that your topology behaviour is or is not dependent on the order in which the events are received and processed. 
+
+In the example below, 2 events are first submitted to topic A, then 3 to topic B, then 1 more to topic A again. 
+
+    val firstInputForTopicA = Seq(("x", int(1)), ("y", int(2)))
+    val firstInputForTopicB = Seq(("x", int(4)), ("y", int(3)), ("y", int(5)))
+    val secondInputForTopicA = Seq(("y", int(4)))
+
+    val expectedOutput = Seq(("x", 5), ("y", 5), ("y", 7), ("y", 9))
+
+    val builder = MockedStreams()
+      .topology(topologyTables)
+      .input(InputATopic, strings, ints, firstInputForTopicA)
+      .input(InputBTopic, strings, ints, firstInputForTopicB)
+      .input(InputATopic, strings, ints, secondInputForTopicA)
+
 ## State Store 
 
 When you define your state stores via .stores(stores: Seq[String]) since 1.2, you are able to verify the state store content via the .stateTable(name: String) method:  

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
 
 val scalaTestVersion = "3.0.2"
 val rocksDBVersion = "5.0.1"
-val kafkaVersion = "0.11.0.0"
+val kafkaVersion = "0.11.0.1"
 
 lazy val kafka = Seq(
    "org.apache.kafka" % "kafka-clients" % kafkaVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.0.0

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0") 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0") 

--- a/src/test/scala/MockedStreamsSpec.scala
+++ b/src/test/scala/MockedStreamsSpec.scala
@@ -227,18 +227,6 @@ class MockedStreamsSpec extends FlatSpec with Matchers {
           .to(strings, ints, OutputATopic)
       }
 
-      def topology1Outputbis(builder: KStreamBuilder) = {
-        val streamA = builder.stream(strings, ints, InputATopic)
-        val streamB = builder.stream(strings, ints, InputBTopic)
-
-        val table = streamB.groupByKey(strings, ints).aggregate(
-          new LastInitializer,
-          new LastAggregator, ints, StoreName)
-
-        streamA.leftJoin[Integer, Integer](table, new AddJoiner(), strings, ints)
-          .to(strings, ints, OutputATopic)
-      }
-
       def topology1WindowOutput(builder: KStreamBuilder) = {
         val streamA = builder.stream(strings, ints, InputCTopic)
         streamA.groupByKey(strings, ints).count(


### PR DESCRIPTION
As discussed in https://github.com/jpzk/mockedstreams/issues/19:

- previously, the events for each mock topic were submitted all at once during
  the test, topic per topic
- this commit ensures that `MockStream` records the order in which the test author
  invoked `input` in the test fixture makes sure they are submitted to the
  topology in that order
- also, I bumbed a few dependencies to the latest minor or patch version (e.g. Kafka upgraded from 0.11.0.0  to 0.11.0.1)