### PR TITLE
Support for Kafka 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Mocked Streams 1.8.0
+
+* Bumping versions of dependencies
+* Build against Apache Kafka 1.1.1
+
 ## Mocked Streams 1.7.0
 
 * Bumping versions of dependencies

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 [![codecov](https://codecov.io/gh/jpzk/mockedstreams/branch/master/graph/badge.svg)](https://codecov.io/gh/jpzk/mockedstreams) [![License](http://img.shields.io/:license-Apache%202-grey.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt) [![GitHub stars](https://img.shields.io/github/stars/jpzk/mockedstreams.svg?style=flat)](https://github.com/jpzk/mockedstreams/stargazers) 
 
 
-Mocked Streams 1.7.0 [(git)](https://github.com/jpzk/mockedstreams) is a library for Scala 2.11 and 2.12 which allows you to **unit-test processing topologies** of [Kafka Streams](https://kafka.apache.org/documentation#streams) applications (since Apache Kafka >=0.10.1) **without Zookeeper and Kafka Brokers**. Further, you can use your favourite Scala testing framework e.g. [ScalaTest](http://www.scalatest.org/) and [Specs2](https://etorreborre.github.io/specs2/). Mocked Streams is located at the Maven Central Repository, therefore you just have to add the following to your [SBT dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html):
+Mocked Streams 1.8.0 [(git)](https://github.com/jpzk/mockedstreams) is a library for Scala 2.11 and 2.12 which allows you to **unit-test processing topologies** of [Kafka Streams](https://kafka.apache.org/documentation#streams) applications (since Apache Kafka >=0.10.1) **without Zookeeper and Kafka Brokers**. Further, you can use your favourite Scala testing framework e.g. [ScalaTest](http://www.scalatest.org/) and [Specs2](https://etorreborre.github.io/specs2/). Mocked Streams is located at the Maven Central Repository, therefore you just have to add the following to your [SBT dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html):
 
-    libraryDependencies += "com.madewithtea" %% "mockedstreams" % "1.7.0" % "test"
+    libraryDependencies += "com.madewithtea" %% "mockedstreams" % "1.8.0" % "test"
 
 ## Apache Kafka Compatibility
 
 | Mocked Streams Version        | Apache Kafka Version           |
 |------------- |-------------|
+| 1.8.0      | 1.1.1.0 |
 | 1.7.0      | 1.1.0.0 |
 | 1.6.0      | 1.0.1.0 |
 | 1.5.0      | 1.0.0.0 |

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 lazy val commonSettings = Seq(
   organization := "com.madewithtea",
-  version := "1.7.0",
+  version := "1.8.0",
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.12.6","2.11.12"),
   description := "Topology Unit-Testing Library for Apache Kafka / Kafka Streams",
@@ -9,8 +9,8 @@ lazy val commonSettings = Seq(
   scalacOptions := Seq("-Xexperimental"))
 
 val scalaTestVersion = "3.0.5"
-val rocksDBVersion = "5.7.3"
-val kafkaVersion = "1.1.0"
+val rocksDBVersion = "5.14.2"
+val kafkaVersion = "1.1.1"
 
 lazy val kafka = Seq(
    "org.apache.kafka" % "kafka-clients" % kafkaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -10,15 +10,17 @@ lazy val commonSettings = Seq(
 
 val scalaTestVersion = "3.0.5"
 val rocksDBVersion = "5.14.2"
-val kafkaVersion = "1.1.1"
+val kafkaVersion = "2.0.0"
 
 lazy val kafka = Seq(
-   "org.apache.kafka" % "kafka-clients" % kafkaVersion,
-   "org.apache.kafka" % "kafka-clients" % kafkaVersion classifier "test",
-   "org.apache.kafka" % "kafka-streams" % kafkaVersion,
-   "org.apache.kafka" % "kafka-streams" % kafkaVersion classifier "test",
-   "org.apache.kafka" %% "kafka" % kafkaVersion 
- )
+  "javax.ws.rs" % "javax.ws.rs-api" % "2.1" jar(),
+  "org.apache.kafka" % "kafka-clients" % kafkaVersion,
+  "org.apache.kafka" % "kafka-clients" % kafkaVersion classifier "test",
+  "org.apache.kafka" % "kafka-streams" % kafkaVersion,
+  "org.apache.kafka" %% "kafka-streams-scala" % kafkaVersion,
+  "org.apache.kafka" % "kafka-streams-test-utils" % kafkaVersion,
+  "org.apache.kafka" %% "kafka" % kafkaVersion
+)
 
 lazy val scalaTest = "org.scalatest" %% "scalatest" % scalaTestVersion % "test"
 lazy val rocksDB = "org.rocksdb" % "rocksdbjni" % rocksDBVersion % "test"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.2
+sbt.version=1.1.6

--- a/src/main/scala/MockedStreams.scala
+++ b/src/main/scala/MockedStreams.scala
@@ -14,14 +14,16 @@
   * See the License for the specific language governing permissions and
   * limitations under the License.
   */
+
 package com.madewithtea.mockedstreams
 
 import java.util.{Properties, UUID}
 
+import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.Serde
-import org.apache.kafka.streams.{StreamsBuilder, StreamsConfig, Topology}
 import org.apache.kafka.streams.state.ReadOnlyWindowStore
-import org.apache.kafka.test.{ProcessorTopologyTestDriver => Driver}
+import org.apache.kafka.streams.test.ConsumerRecordFactory
+import org.apache.kafka.streams.{StreamsBuilder, StreamsConfig, Topology, TopologyTestDriver => Driver}
 
 import scala.collection.JavaConverters._
 
@@ -29,16 +31,14 @@ object MockedStreams {
 
   def apply() = Builder()
 
-  case class Record(topic: String, key: Array[Byte], value: Array[Byte])
-
   case class Builder(topology: Option[() => Topology] = None,
                      configuration: Properties = new Properties(),
                      stateStores: Seq[String] = Seq(),
-                     inputs: List[Record] = List.empty) {
+                     inputs: List[ConsumerRecord[Array[Byte], Array[Byte]]] = List.empty) {
 
     def config(configuration: Properties) = this.copy(configuration = configuration)
 
-    def topology(func: (StreamsBuilder => Unit)) = {
+    def topology(func: StreamsBuilder => Unit) = {
       val buildTopology = () => {
         val builder = new StreamsBuilder()
         func(builder)
@@ -55,9 +55,11 @@ object MockedStreams {
       val keySer = key.serializer
       val valSer = value.serializer
 
+      val factory = new ConsumerRecordFactory[K, V](keySer, valSer)
+
       val updatedRecords = newRecords.foldLeft(inputs) {
         case (events, (k, v)) =>
-          val newRecord = Record(topic, keySer.serialize(topic, k), valSer.serialize(topic, v))
+          val newRecord = factory.create(topic, k, v)
           events :+ newRecord
       }
 
@@ -97,22 +99,18 @@ object MockedStreams {
 
     // state store is temporarily created in ProcessorTopologyTestDriver
     private def stream = {
-      val props: java.util.Map[Object, Object] = new Properties
+      val props = new Properties
       props.put(StreamsConfig.APPLICATION_ID_CONFIG, s"mocked-${UUID.randomUUID().toString}")
       props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")
       props.putAll(configuration)
 
-      val t = topology.getOrElse(throw new NoTopologySpecified)
+      val t: () => Topology = topology.getOrElse(throw new NoTopologySpecified)
 
-      new Driver(new StreamsConfig(props), t())
+      new Driver(t(), props)
     }
 
-    private def produce(driver: Driver): Unit = {
-      inputs.foreach {
-        case Record(topic, key, value) =>
-          driver.process(topic, key, value)
-      }
-    }
+    private def produce(driver: Driver): Unit =
+      inputs.foreach(driver.pipeInput)
 
     private def withProcessedDriver[T](f: Driver => T): T = {
       if(inputs.isEmpty)


### PR DESCRIPTION
Changes to support Kafka 2.0:
- replaced ProcessorTopologyTestDriver with TopologyTestDriver
- removed Record class to use ConsumerRecord directly

There is a new scala DSL, so next step is to upgrade to use it, rather than deal with java DSL that requires explicit passing of serdes.