### PR TITLE
feature/nitay/bumpKafkaTo2.0.1: bump kafka streams version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Mocked Streams 2.1.1
+
+* Bumping version of kafka streams (2.0.0 -> 2.0.1)
+
 ## Mocked Streams 2.1
 
 * Added .inputWithTime to allow custom timestamps 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 [![codecov](https://codecov.io/gh/jpzk/mockedstreams/branch/master/graph/badge.svg)](https://codecov.io/gh/jpzk/mockedstreams) [![License](http://img.shields.io/:license-Apache%202-grey.svg)](http://www.apache.org/licenses/LICENSE-2.0.txt) [![GitHub stars](https://img.shields.io/github/stars/jpzk/mockedstreams.svg?style=flat)](https://github.com/jpzk/mockedstreams/stargazers) 
 
 
-Mocked Streams 2.1.0 [(git)](https://github.com/jpzk/mockedstreams) is a library for Scala 2.11 and 2.12 which allows you to **unit-test processing topologies** of [Kafka Streams](https://kafka.apache.org/documentation#streams) applications (since Apache Kafka >=0.10.1) **without Zookeeper and Kafka Brokers**. Further, you can use your favourite Scala testing framework e.g. [ScalaTest](http://www.scalatest.org/) and [Specs2](https://etorreborre.github.io/specs2/). Mocked Streams is located at the Maven Central Repository, therefore you just have to add the following to your [SBT dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html):
+Mocked Streams 2.1.1 [(git)](https://github.com/jpzk/mockedstreams) is a library for Scala 2.11 and 2.12 which allows you to **unit-test processing topologies** of [Kafka Streams](https://kafka.apache.org/documentation#streams) applications (since Apache Kafka >=0.10.1) **without Zookeeper and Kafka Brokers**. Further, you can use your favourite Scala testing framework e.g. [ScalaTest](http://www.scalatest.org/) and [Specs2](https://etorreborre.github.io/specs2/). Mocked Streams is located at the Maven Central Repository, therefore you just have to add the following to your [SBT dependencies](http://www.scala-sbt.org/0.13/docs/Library-Dependencies.html):
 
-    libraryDependencies += "com.madewithtea" %% "mockedstreams" % "2.1.0" % "test"
+    libraryDependencies += "com.madewithtea" %% "mockedstreams" % "2.1.1" % "test"
 
 Java 8 port of Mocked Streams is [Mockafka](https://github.com/carlosmenezes/mockafka)
 
@@ -14,18 +14,19 @@ Java 8 port of Mocked Streams is [Mockafka](https://github.com/carlosmenezes/moc
 
 | Mocked Streams Version        | Apache Kafka Version           |
 |------------- |-------------|
-| 2.1.0      | 2.0.0.0 | 
-  2.0.0      | 2.0.0.0 |
-| 1.8.0      | 1.1.1.0 |
-| 1.7.0      | 1.1.0.0 |
-| 1.6.0      | 1.0.1.0 |
-| 1.5.0      | 1.0.0.0 |
-| 1.4.0      | 0.11.0.1 | 
-| 1.3.0      | 0.11.0.0 | 
-| 1.2.1      | 0.10.2.1 | 
-| 1.2.0      | 0.10.2.0 | 
-| 1.1.0      | 0.10.1.1 | 
-| 1.0.0      | 0.10.1.0      |    
+| 2.1.1        | 2.0.1.0     | 
+| 2.1.0        | 2.0.0.0     | 
+| 2.0.0        | 2.0.0.0     |
+| 1.8.0        | 1.1.1.0     |
+| 1.7.0        | 1.1.0.0     |
+| 1.6.0        | 1.0.1.0     |
+| 1.5.0        | 1.0.0.0     |
+| 1.4.0        | 0.11.0.1    | 
+| 1.3.0        | 0.11.0.0    | 
+| 1.2.1        | 0.10.2.1    | 
+| 1.2.0        | 0.10.2.0    | 
+| 1.1.0        | 0.10.1.1    | 
+| 1.0.0        | 0.10.1.0    |    
 
 
 ## Simple Example

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 
 lazy val commonSettings = Seq(
   organization := "com.madewithtea",
-  version := "2.1.0",
+  version := "2.1.1",
   scalaVersion := "2.12.6",
   crossScalaVersions := Seq("2.12.6","2.11.12"),
   description := "Topology Unit-Testing Library for Apache Kafka / Kafka Streams",
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
 
 val scalaTestVersion = "3.0.5"
 val rocksDBVersion = "5.14.2"
-val kafkaVersion = "2.0.0"
+val kafkaVersion = "2.0.1"
 
 lazy val kafka = Seq(
   "javax.ws.rs" % "javax.ws.rs-api" % "2.1" jar(),


### PR DESCRIPTION
Relates to the following [issue](https://github.com/jpzk/mockedstreams/issues/40)