### PR TITLE
Update Kafka Version to 2.6.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Java 8 port of Mocked Streams is [Mockafka](https://github.com/carlosmenezes/moc
 
 | Mocked Streams Version        | Apache Kafka Version           |
 |------------- |-------------|
+| 3.8.0     | 2.6.1.0 |
 | 3.7.0     | 2.5.0.0 |
 | 3.6.0      | 2.4.1.0 |
 | 3.5.2      | 2.4.0.0 |

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 lazy val commonSettings = Seq(
   organization := "com.madewithtea",
-  version := "3.7.0",
+  version := "3.8.0",
   scalaVersion := "2.13.1",
   crossScalaVersions := List("2.12.10", "2.13.1"),
   description := "Topology Unit-Testing Library for Kafka Streams",
@@ -10,7 +10,7 @@ lazy val commonSettings = Seq(
 
 val scalaTestVersion = "3.0.8"
 val rocksDBVersion = "5.18.4"
-val kafkaVersion = "2.5.0"
+val kafkaVersion = "2.6.1"
 
 lazy val kafka = Seq(
   "org.apache.kafka" % "kafka-clients" % kafkaVersion,


### PR DESCRIPTION
When testing with the latest release version of your library and kafka streams `2.6.x` or greater, I experienced an exception there to the topologies would not start.

However, at the time I am submitting this PR, I rolled my example project back to the `3.7.0` version of your api and I am unable to reproduce what I saw a day ago... 

At any rate, let me know what you think of this and if you feel it is worth a merge...

Cheers,
Sandon Jacobs